### PR TITLE
Meta: Documentation for COMMITTING.md

### DIFF
--- a/COMMITTING.md
+++ b/COMMITTING.md
@@ -1,0 +1,55 @@
+# WHATWG committer guidelines
+
+## Branches
+
+Branches are transient and their names must be detailed enough to avoid confusion. Choose short and descriptive names. Using hyphens to separate words is encouraged _(but not required)_.
+
+```bash
+# good
+$ git checkout -b descriptive-name-relative-to-feature
+```
+
+```bash
+# bad - too vague and malformatted
+$ git checkout -b fix_paragraph-header
+```
+
+Identifiers from corresponding Github issues are great candidates for use in branch names. For example, when working on an issue:
+
+```bash
+$ git checkout -b issue-15
+```
+
+## Committing
+
+Each change needs to result in a single commit on the master branch, with no merge commits. The green squash and merge button is OK to use, but be sure to tidy up the commit message per [guidelines for writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).
+
+Prefix the summary line with "Editorial: " if the change is just to fix formatting, typos, or is a refactoring that does not change how the standard is understood. Note that bug fixes or clarifications are not editorial, even if they only affect non-normative text.
+
+Prefix the summary line with "Meta: " for changes that do not directly affect the text of the standard, but instead the ecosystem around it, such as spec tooling or contributor documentation.
+
+## Conventions
+
+Write a title and message that will allow your future self to understand the intent of change without looking at the diff. This will not only benefit the author but also the reviewer and will better allow intent expression versus implementation details.
+
+## Example
+
+From: http://git-scm.com/book/ch5-2.html
+
+```
+Provide a short summary of changes
+ [line intentionally left blank]
+More detailed explanatory text, if necessary.  Wrap it to about 72
+characters or so.  In some contexts, the first line is treated as the
+subject of an email and the rest of the text as the body.  The blank
+line separating the summary from the body is critical (unless you omit
+the body entirely); tools like rebase can get confused if you run the
+two together.
+
+Further paragraphs come after blank lines.
+
+  - Bullet points are okay, too
+
+  - Typically a hyphen or asterisk is used for the bullet, preceded by a
+    single space, with blank lines in between, but conventions vary here
+```

--- a/COMMITTING.md
+++ b/COMMITTING.md
@@ -1,16 +1,71 @@
 # WHATWG committer guidelines
 
+## General
+
+Each change needs to result in a single commit on the master branch, with no merge commits. The green squash and merge button is OK to use, but be sure to tidy up the commit message per the below guidelines. In particular, if you use the squash functionality, delete the parenthetical pull request number that GitHub adds.
+
+## Commit messages
+
+_(Some of this is derived from [the erlang/otp wiki](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).)_
+
+### Purpose
+
+Good commit messages serve at least three important purposes:
+
+* To help pull requests reviewers understand what is being changed.
+* To make it easy and pleasant to review the history of the repository.
+* To help future maintainers find out why a particular change was made.
+
+As such, you should write a commit message that will allow your future self to understand the intent of change without looking at the diff. This will not only benefit the maintainers, but also the reviewers. You should express the intent of the change, without focusing on the implementation details.
+
+For more on this topic, see ["On commit messages"](http://who-t.blogspot.com/2009/12/on-commit-messages.html).
+
+### Structure and conventions
+
+Commit messages consist of a single title line, a blank line, and then a more detailed change description. The description (and preceding blank line) may be omitted for simple fixes.
+
+All lines should be at most 72 characters, to make them easier to view in GitHub and other tools. (Some sources recommend restricting the title line to 50 characters, but we do not enforce this.)
+
+The title must be written in imperative mode, as if you were commanding someone. This means using verb conjugations like "fix"/"add"/"change" instead of "fixed"/"added"/"changed" or "fixing"/"adding"/"changing". We are less consistent with the description, but often use present tense ("This change adds...").
+
+Title lines must not end in a period; they are titles, not sentences.
+
+Be sure to reference the appropriate GitHub issue if your work is related to one, so that it gets appropriately cross-linked by GitHub. Use "closes" or "fixes" as appropriate to [automatically close issues](https://help.github.com/articles/closing-issues-using-keywords/).
+
+Avoid using Markdown-style code markup (i.e. backticks) unless necessary for disambiguation.
+
+### Title prefixes
+
+Prefix the title line with "Editorial: " if the change is just to fix formatting, typos, or is a refactoring that does not change how the standard is understood. Note that bug fixes or clarifications are not editorial, even if they only affect non-normative text.
+
+Prefix the title line with "Meta: " for changes that do not directly affect the text of the standard, but instead the ecosystem around it, such as spec tooling or contributor documentation.
+
+In general, most commits do not have a prefix.
+
+### Example
+
+From [whatwg/html@54585](https://github.com/whatwg/html/commit/5458513792ab00d58e6c91ba48faaa611d034a2e):
+
+```
+Editorial: move base URL from "module script" to "script"
+
+This propagates an appropriate base URL for all instances of creating a
+classic script. This has no effect by itself (and indeed looks kind of
+pointless as of this commit), but it sets the stage for making import()
+use this base URL (#2315).
+```
+
 ## Branches
 
-Branches are transient and their names must be detailed enough to avoid confusion. Choose short and descriptive names. Using hyphens to separate words is encouraged _(but not required)_.
+Branches are transient and their names should be detailed enough to avoid confusion. Choose short and descriptive names. Using hyphens to separate words is encouraged.
 
 ```bash
 # good
-$ git checkout -b descriptive-name-relative-to-feature
+$ git checkout -b modernize-template-header
 ```
 
 ```bash
-# bad - too vague and malformatted
+# bad: too vague and malformatted
 $ git checkout -b fix_paragraph-header
 ```
 
@@ -18,38 +73,4 @@ Identifiers from corresponding Github issues are great candidates for use in bra
 
 ```bash
 $ git checkout -b issue-15
-```
-
-## Committing
-
-Each change needs to result in a single commit on the master branch, with no merge commits. The green squash and merge button is OK to use, but be sure to tidy up the commit message per [guidelines for writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).
-
-Prefix the summary line with "Editorial: " if the change is just to fix formatting, typos, or is a refactoring that does not change how the standard is understood. Note that bug fixes or clarifications are not editorial, even if they only affect non-normative text.
-
-Prefix the summary line with "Meta: " for changes that do not directly affect the text of the standard, but instead the ecosystem around it, such as spec tooling or contributor documentation.
-
-## Conventions
-
-Write a title and message that will allow your future self to understand the intent of change without looking at the diff. This will not only benefit the author but also the reviewer and will better allow intent expression versus implementation details.
-
-## Example
-
-From: http://git-scm.com/book/ch5-2.html
-
-```
-Provide a short summary of changes
- [line intentionally left blank]
-More detailed explanatory text, if necessary.  Wrap it to about 72
-characters or so.  In some contexts, the first line is treated as the
-subject of an email and the rest of the text as the body.  The blank
-line separating the summary from the body is critical (unless you omit
-the body entirely); tools like rebase can get confused if you run the
-two together.
-
-Further paragraphs come after blank lines.
-
-  - Bullet points are okay, too
-
-  - Typically a hyphen or asterisk is used for the bullet, preceded by a
-    single space, with blank lines in between, but conventions vary here
 ```

--- a/COMMITTING.md
+++ b/COMMITTING.md
@@ -23,23 +23,23 @@ For more on this topic, see ["On commit messages"](http://who-t.blogspot.com/200
 
 ### Structure and conventions
 
-Commit messages consist of a single title line, a blank line, and then a more detailed change description. The description _(and preceding blank line)_ may be omitted for simple fixes.
+Commit messages consist of a single title line, a blank line, and then a more detailed change description. The description (and preceding blank line) may be omitted for simple fixes.
 
 All lines should be at most 72 characters, to make them easier to view in GitHub and other tools. Some sources recommend restricting the title line to 50 characters, but we do not enforce this.
 
-The title must be written in imperative mode, as if commanding someone. This means using verb conjugations such as _"fix"_/_"add"_/_"change"_ instead of _"fixed"_/_"added"_/_"changed"_ or _"fixing"_/_"adding"_/_"changing"_. We are less consistent with the description, but often use present tense _(i.e. "This change adds…")_.
+The title must be written in imperative mode, as if commanding someone. This means using verb conjugations such as "fix"/"add"/"change" instead of "fixed"/"added"/"changed" or "fixing"/"adding"/"changing". We are less consistent with the description, but often use present tense (i.e. "This change adds…").
 
 Title lines must not end in a period; they are titles, not sentences.
 
-Be sure to reference related GitHub issues within pull requests so they are appropriately cross-linked by GitHub. Use _"closes"_ or _"fixes"_ as appropriate to [automatically close issues](https://help.github.com/articles/closing-issues-using-keywords/).
+Be sure to reference related GitHub issues within pull requests so they are appropriately cross-linked by GitHub. Use "closes" or "fixes" as appropriate to [automatically close issues](https://help.github.com/articles/closing-issues-using-keywords/).
 
-Avoid using Markdown-style code markup _(i.e. backticks `` )_ unless necessary for disambiguation.
+Avoid using Markdown-style code markup (i.e. backticks `` ) unless necessary for disambiguation.
 
 ### Title prefixes
 
-Prefix the title line with _**"Editorial: "**_ if the change is just to fix formatting, typos, or is a refactoring that does not change how the standard is understood. Note that bug fixes or clarifications are not editorial, even if they only affect non-normative text.
+Prefix the title line with **"Editorial: "** if the change is just to fix formatting, typos, or is a refactoring that does not change how the standard is understood. Note that bug fixes or clarifications are not editorial, even if they only affect non-normative text.
 
-Prefix the title line with _**"Meta: "**_ for changes that do not directly affect the text of the standard, but instead the ecosystem around it, such as spec tooling or contributor documentation.
+Prefix the title line with **"Meta: "** for changes that do not directly affect the text of the standard, but instead the ecosystem around it, such as spec tooling or contributor documentation.
 
 In general, most commits do not have a prefix.
 

--- a/COMMITTING.md
+++ b/COMMITTING.md
@@ -17,7 +17,7 @@ Great commit messages serve at least three important purposes:
 * To make it easy and pleasant to review the history of the repository.
 * To help future maintainers find out why a particular change was made.
 
-As such, a commit message should be written which allows your future self to understand the intent of change without needing to delve into implementation details. This will not only benefit the maintainers, but also the reviewers.
+As such, you should write a commit message that will allow your future self to understand the intent of change without looking at the diff. This will not only benefit reviewers, but also other maintainers. Your commit message should express intent without delving into implementation details.
 
 For more on this topic, see ["On commit messages"](http://who-t.blogspot.com/2009/12/on-commit-messages.html).
 

--- a/COMMITTING.md
+++ b/COMMITTING.md
@@ -33,7 +33,7 @@ Title lines must not end in a period; they are titles, not sentences.
 
 Be sure to reference related GitHub issues within pull requests so they are appropriately cross-linked by GitHub. Use "closes" or "fixes" as appropriate to [automatically close issues](https://help.github.com/articles/closing-issues-using-keywords/).
 
-Avoid using Markdown-style code markup (i.e. backticks `` ) unless necessary for disambiguation.
+Avoid using Markdown-style code markup (i.e. backticks) unless necessary for disambiguation.
 
 ### Title prefixes
 

--- a/COMMITTING.md
+++ b/COMMITTING.md
@@ -5,11 +5,9 @@
 
 Each change needs to result in a single commit on the master branch, with no merge commits. The green squash and merge button is OK to use, but be sure to tidy up the commit message per the below guidelines. In particular, if you use the squash functionality, delete the parenthetical pull request number that GitHub adds.
 
-
 ## Commit messages
 
 _(Derived from the [erlang/otp wiki](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).)_
-
 
 ### Purpose
 
@@ -22,7 +20,6 @@ Great commit messages serve at least three important purposes:
 As such, a commit message should be written which allows your future self to understand the intent of change without needing to delve into implementation details. This will not only benefit the maintainers, but also the reviewers.
 
 For more on this topic, see ["On commit messages"](http://who-t.blogspot.com/2009/12/on-commit-messages.html).
-
 
 ### Structure and conventions
 
@@ -38,7 +35,6 @@ Be sure to reference related GitHub issues within pull requests so they are appr
 
 Avoid using Markdown-style code markup _(i.e. backticks `` )_ unless necessary for disambiguation.
 
-
 ### Title prefixes
 
 Prefix the title line with _**"Editorial: "**_ if the change is just to fix formatting, typos, or is a refactoring that does not change how the standard is understood. Note that bug fixes or clarifications are not editorial, even if they only affect non-normative text.
@@ -46,7 +42,6 @@ Prefix the title line with _**"Editorial: "**_ if the change is just to fix form
 Prefix the title line with _**"Meta: "**_ for changes that do not directly affect the text of the standard, but instead the ecosystem around it, such as spec tooling or contributor documentation.
 
 In general, most commits do not have a prefix.
-
 
 ### Example
 
@@ -60,7 +55,6 @@ classic script. This has no effect by itself (and indeed looks kind of
 pointless as of this commit), but it sets the stage for making import()
 use this base URL (#2315).
 ```
-
 
 ## Branches
 

--- a/COMMITTING.md
+++ b/COMMITTING.md
@@ -1,46 +1,52 @@
 # WHATWG committer guidelines
 
+
 ## General
 
 Each change needs to result in a single commit on the master branch, with no merge commits. The green squash and merge button is OK to use, but be sure to tidy up the commit message per the below guidelines. In particular, if you use the squash functionality, delete the parenthetical pull request number that GitHub adds.
 
+
 ## Commit messages
 
-_(Some of this is derived from [the erlang/otp wiki](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).)_
+_(Derived from the [erlang/otp wiki](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).)_
+
 
 ### Purpose
 
-Good commit messages serve at least three important purposes:
+Great commit messages serve at least three important purposes:
 
 * To help pull requests reviewers understand what is being changed.
 * To make it easy and pleasant to review the history of the repository.
 * To help future maintainers find out why a particular change was made.
 
-As such, you should write a commit message that will allow your future self to understand the intent of change without looking at the diff. This will not only benefit the maintainers, but also the reviewers. You should express the intent of the change, without focusing on the implementation details.
+As such, a commit message should be written which allows your future self to understand the intent of change without needing to delve into implementation details. This will not only benefit the maintainers, but also the reviewers.
 
 For more on this topic, see ["On commit messages"](http://who-t.blogspot.com/2009/12/on-commit-messages.html).
 
+
 ### Structure and conventions
 
-Commit messages consist of a single title line, a blank line, and then a more detailed change description. The description (and preceding blank line) may be omitted for simple fixes.
+Commit messages consist of a single title line, a blank line, and then a more detailed change description. The description _(and preceding blank line)_ may be omitted for simple fixes.
 
-All lines should be at most 72 characters, to make them easier to view in GitHub and other tools. (Some sources recommend restricting the title line to 50 characters, but we do not enforce this.)
+All lines should be at most 72 characters, to make them easier to view in GitHub and other tools. Some sources recommend restricting the title line to 50 characters, but we do not enforce this.
 
-The title must be written in imperative mode, as if you were commanding someone. This means using verb conjugations like "fix"/"add"/"change" instead of "fixed"/"added"/"changed" or "fixing"/"adding"/"changing". We are less consistent with the description, but often use present tense ("This change adds...").
+The title must be written in imperative mode, as if commanding someone. This means using verb conjugations such as _"fix"_/_"add"_/_"change"_ instead of _"fixed"_/_"added"_/_"changed"_ or _"fixing"_/_"adding"_/_"changing"_. We are less consistent with the description, but often use present tense _(i.e. "This change adds…")_.
 
 Title lines must not end in a period; they are titles, not sentences.
 
-Be sure to reference the appropriate GitHub issue if your work is related to one, so that it gets appropriately cross-linked by GitHub. Use "closes" or "fixes" as appropriate to [automatically close issues](https://help.github.com/articles/closing-issues-using-keywords/).
+Be sure to reference related GitHub issues within pull requests so they are appropriately cross-linked by GitHub. Use _"closes"_ or _"fixes"_ as appropriate to [automatically close issues](https://help.github.com/articles/closing-issues-using-keywords/).
 
-Avoid using Markdown-style code markup (i.e. backticks) unless necessary for disambiguation.
+Avoid using Markdown-style code markup _(i.e. backticks `` )_ unless necessary for disambiguation.
+
 
 ### Title prefixes
 
-Prefix the title line with "Editorial: " if the change is just to fix formatting, typos, or is a refactoring that does not change how the standard is understood. Note that bug fixes or clarifications are not editorial, even if they only affect non-normative text.
+Prefix the title line with _**"Editorial: "**_ if the change is just to fix formatting, typos, or is a refactoring that does not change how the standard is understood. Note that bug fixes or clarifications are not editorial, even if they only affect non-normative text.
 
-Prefix the title line with "Meta: " for changes that do not directly affect the text of the standard, but instead the ecosystem around it, such as spec tooling or contributor documentation.
+Prefix the title line with _**"Meta: "**_ for changes that do not directly affect the text of the standard, but instead the ecosystem around it, such as spec tooling or contributor documentation.
 
 In general, most commits do not have a prefix.
+
 
 ### Example
 
@@ -54,6 +60,7 @@ classic script. This has no effect by itself (and indeed looks kind of
 pointless as of this commit), but it sets the stage for making import()
 use this base URL (#2315).
 ```
+
 
 ## Branches
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 These are the general guidelines for contributing to WHATWG standards.
 
+## Committing
+
+See [COMMITTING.md](COMMITTING.md) for further details.
+
 ## Pull requests
 
 Leave the **Allow edits from maintainers** option enabled to allow reviewers to fix trivial issues directly on your branch rather than needing to write review comments asking you make the edits.  For more details, see [Improving collaboration with forks](https://github.com/blog/2247-improving-collaboration-with-forks) in the GitHub Blog.

--- a/TEAM.md
+++ b/TEAM.md
@@ -4,11 +4,7 @@ These are the general guidelines for maintaining WHATWG standards. Mostly boring
 
 ## Handling pull requests
 
-Each change needs to result in a single commit on the master branch, with no merge commits. The green squash and merge button is OK to use, but be sure to tidy up the commit message per [guidelines for writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).
-
-Prefix the summary line with "Editorial: " if the change is just to fix formatting, typos, or is a refactoring that does not change how the standard is understood. Note that bug fixes or clarifications are not editorial, even if they only affect non-normative text.
-
-Prefix the summary line with "Meta: " for changes that do not directly affect the text of the standard, but instead the ecosystem around it, such as spec tooling or contributor documentation.
+Rules for title/message must be satisfied before pull request is reviewed. See [COMMITTING.md](COMMITTING.md) for further details.
 
 For normative changes, ask for a [web-platform-tests](https://github.com/w3c/web-platform-tests) PR if testing is practical and not overly burdensome. Aim to merge both PRs at the same time. If one PR is approved but the other needs more work, add the `do not merge yet` label or, in web-platform-tests, the `status:needs-spec-decision` label.
 


### PR DESCRIPTION
Resolves #37 

This commit is a meta, meta contribution which
arose from a discussion with @annevk and @domenic

The following task list was completed using the
"conventions may vary here" convention
from http://git-scm.com/book/ch5-2.html

- [x] Create document `COMMITTING.md`
- [x] Document `Branches` section
- [x] Migrate `TEAM.md#handling-pull-requests` introduction
  - [x] Copy first three paragraphs from TEAM.md#handling-pull-requests
- [x] Update `CONTRIBUTING.md` with briefing and link to `COMMITTING.md`
- [x] Pull in relevant examples from https://github.com/erlang/otp/wiki/Writing-good-commit-messages

Also may want to update link to `contribute.md` after merge but should be in a different PR.
![capture d ecran 2017-09-22 a 15 37 35](https://user-images.githubusercontent.com/38223/30766757-1d63dfe2-9fac-11e7-929c-eaf3b12bfe6e.png)
