### PR TITLE
Add Getting Started section to Contributor Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,14 @@ These are the general guidelines for contributing to WHATWG standards.
 
 See [COMMITTING.md](COMMITTING.md) for further details.
 
+## Getting Started
+
+If this is your first time contributing to the WHATWG standards, check out the global list of [good first issues](https://github.com/search?q=is%3Aopen+label%3A%22good+first+issue%22+user%3Awhatwg&type=Issues) and find one you want to work on. You should comment in the thread to let others know that you want on the issue. This is a great time to ask any questions that you may have.
+
+Contributions to older issues are always appreciated. If an issue hasn't been updated in a while, you should ask if the issue is still relevant before working on it. If someone else was previously working on an issue, and you want to work on it, it's polite to ask that person if you can work on the issue before taking it.
+
+When an issue is inactive or not depends on the type of issue. In general, issues that haven't been updated in 90 days are considered inactive.
+
 ## Pull requests
 
 Leave the **Allow edits from maintainers** option enabled to allow reviewers to fix trivial issues directly on your branch rather than needing to write review comments asking you make the edits. For more details, see [Improving collaboration with forks](https://github.com/blog/2247-improving-collaboration-with-forks) in the GitHub Blog.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,9 @@ See [COMMITTING.md](COMMITTING.md) for further details.
 
 ## Getting Started
 
-If this is your first time contributing to the WHATWG standards, check out the global list of [good first issues](https://github.com/search?q=is%3Aopen+label%3A%22good+first+issue%22+user%3Awhatwg&type=Issues) and find one you want to work on. You should comment in the thread to let others know that you want on the issue. This is a great time to ask any questions that you may have.
+If this is your first time contributing to the WHATWG standards, check out the global list of [good first issues](https://github.com/search?q=is%3Aopen+label%3A%22good+first+issue%22+user%3Awhatwg&type=Issues) and find one you want to work on. You should comment in the thread to let others know you will be working on the issue. This is a great time to ask any questions that you may have.
 
 Contributions to older issues are always appreciated. If an issue hasn't been updated in a while, you should ask if the issue is still relevant before working on it. If someone else was previously working on an issue, and you want to work on it, it's polite to ask that person if you can work on the issue before taking it.
-
-When an issue is inactive or not depends on the type of issue. In general, issues that haven't been updated in 90 days are considered inactive.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ These are the general guidelines for contributing to WHATWG standards.
 
 See [COMMITTING.md](COMMITTING.md) for further details.
 
-## Getting Started
+## Getting started
 
 If this is your first time contributing to the WHATWG standards, check out the global list of [good first issues](https://github.com/search?q=is%3Aopen+label%3A%22good+first+issue%22+user%3Awhatwg&type=Issues) and find one you want to work on. You should comment in the thread to let others know you will be working on the issue. This is a great time to ask any questions that you may have.
 


### PR DESCRIPTION
This change attempts to lower the barrier to entry for potential contributors.

It addresses the following:

- Finding good first issues
- Commenting and asking questions on issues
- Contributing to older issues

Would appreciate a review.

Ref: #74 