### PR TITLE
Add anchor-permanence label

### DIFF
--- a/LABELS.md
+++ b/LABELS.md
@@ -5,6 +5,6 @@ There is currently no WHATWG-wide label policy, except for:
 * [good first issue](https://github.com/search?q=org%3Awhatwg+label%3A%22good+first+issue%22+is%3Aopen): identifies issues someone new to a WHATWG standard or software project can take on
 * [i18n-comment](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-comment+is%3Aopen): used by the internationalization community to track issues they have raised.
 * [i18n-tracking](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-tracking+is%3Aopen): used by the internationalization community to track issues they are interested in or the WHATWG community thinks the internationalization community might be interested in.
-* [anchor-permanence](https://github.com/search?q=org%3Awhatwg+label%3Aanchor-permanence): identifies issues opened by other standards organizations or documentation curators indicating to an editor that a certain anchor is being referenced and should work forever.
+* [anchor-permanence](https://github.com/search?q=org%3Awhatwg+label%3Aanchor-permanence): identifies issues opened by other standards organizations, under our [anchor permanence policy](https://whatwg.org/working-mode#anchors), indicating to an editor that a certain anchor is being referenced and should work forever.
 
 Using these labels results in digest email to [www-international](https://lists.w3.org/Archives/Public/www-international/).

--- a/LABELS.md
+++ b/LABELS.md
@@ -5,5 +5,6 @@ There is currently no WHATWG-wide label policy, except for:
 * [good first issue](https://github.com/search?q=org%3Awhatwg+label%3A%22good+first+issue%22+is%3Aopen): identifies issues someone new to a WHATWG standard or software project can take on
 * [i18n-comment](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-comment+is%3Aopen): used by the internationalization community to track issues they have raised.
 * [i18n-tracking](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-tracking+is%3Aopen): used by the internationalization community to track issues they are interested in or the WHATWG community thinks the internationalization community might be interested in.
+* [anchor-permanence](https://github.com/search?q=org%3Awhatwg+label%3Aanchor-permanence+is%3Aopen): identifies issues opened by other standards organizations or documentation curators indicating to an editor that a certain anchor is being referenced and should work forever.
 
 Using these labels results in digest email to [www-international](https://lists.w3.org/Archives/Public/www-international/).

--- a/LABELS.md
+++ b/LABELS.md
@@ -5,6 +5,6 @@ There is currently no WHATWG-wide label policy, except for:
 * [good first issue](https://github.com/search?q=org%3Awhatwg+label%3A%22good+first+issue%22+is%3Aopen): identifies issues someone new to a WHATWG standard or software project can take on
 * [i18n-comment](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-comment+is%3Aopen): used by the internationalization community to track issues they have raised.
 * [i18n-tracking](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-tracking+is%3Aopen): used by the internationalization community to track issues they are interested in or the WHATWG community thinks the internationalization community might be interested in.
-* [anchor-permanence](https://github.com/search?q=org%3Awhatwg+label%3Aanchor-permanence): identifies issues opened by other standards organizations, under our [anchor permanence policy](https://whatwg.org/working-mode#anchors), indicating to an editor that a certain anchor is being referenced and should work forever.
+* [anchor permanence](https://github.com/search?q=org%3Awhatwg+label%3Aanchor+permanence): identifies issues opened by other standards organizations, under our [anchor permanence policy](https://whatwg.org/working-mode#anchors), indicating to an editor that a certain anchor is being referenced and should work forever.
 
 Using these labels results in digest email to [www-international](https://lists.w3.org/Archives/Public/www-international/).

--- a/LABELS.md
+++ b/LABELS.md
@@ -5,6 +5,6 @@ There is currently no WHATWG-wide label policy, except for:
 * [good first issue](https://github.com/search?q=org%3Awhatwg+label%3A%22good+first+issue%22+is%3Aopen): identifies issues someone new to a WHATWG standard or software project can take on
 * [i18n-comment](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-comment+is%3Aopen): used by the internationalization community to track issues they have raised.
 * [i18n-tracking](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-tracking+is%3Aopen): used by the internationalization community to track issues they are interested in or the WHATWG community thinks the internationalization community might be interested in.
-* [anchor-permanence](https://github.com/search?q=org%3Awhatwg+label%3Aanchor-permanence+is%3Aopen): identifies issues opened by other standards organizations or documentation curators indicating to an editor that a certain anchor is being referenced and should work forever.
+* [anchor-permanence](https://github.com/search?q=org%3Awhatwg+label%3Aanchor-permanence): identifies issues opened by other standards organizations or documentation curators indicating to an editor that a certain anchor is being referenced and should work forever.
 
 Using these labels results in digest email to [www-international](https://lists.w3.org/Archives/Public/www-international/).


### PR DESCRIPTION
I'm trying to figure out when anchor permanence issues should be closed, because it probably doesn't make sense to just always leave them open always. Maybe right when the label is applied, the issue could be closed. Then before an editor makes an anchor-modifying change, they could look through the link in this file to see if any outstanding requests justify moving the current anchor to the `oldids` section, to honor the request. In this case, we should probably not have `+is%3Aopen` appended to the issue link in this file. Thoughts?