### PR TITLE
Propose impacts documentation label

### DIFF
--- a/LABELS.md
+++ b/LABELS.md
@@ -5,6 +5,7 @@ There is currently no WHATWG-wide label policy, except for:
 * [good first issue](https://github.com/search?q=org%3Awhatwg+label%3A%22good+first+issue%22+is%3Aopen): identifies issues someone new to a WHATWG standard or software project can take on
 * [i18n-comment](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-comment+is%3Aopen): used by the internationalization community to track issues they have raised.
 * [i18n-tracking](https://github.com/search?q=org%3Awhatwg+label%3Ai18n-tracking+is%3Aopen): used by the internationalization community to track issues they are interested in or the WHATWG community thinks the internationalization community might be interested in.
-* [anchor permanence](https://github.com/search?q=org%3Awhatwg+label%3Aanchor+permanence): identifies issues opened by other standards organizations, under our [anchor permanence policy](https://whatwg.org/working-mode#anchors), indicating to an editor that a certain anchor is being referenced and should work forever.
+* [anchor permanence](https://github.com/search?q=org%3Awhatwg+label%3A%22anchor+permanence%22): identifies issues opened by other standards organizations, under our [anchor permanence policy](https://whatwg.org/working-mode#anchors), indicating to an editor that a certain anchor is being referenced and should work forever.
+* [impacts documentation](https://github.com/search?q=org%3Awhatwg+label%3A%22impacts+documentation%22): used by documentation communities, such as MDN, to track changes to standards that the WHATWG community believes have an impact on documentation.
 
 Using these labels results in digest email to [www-international](https://lists.w3.org/Archives/Public/www-international/).


### PR DESCRIPTION
Should close #62 . I've generalized the label a bit, I'm not sure if the intention of the label was to be MDN-specific (does the WHATWG have any forma affiliation with that network?), but if so I'm happy to make the label `mdn relevant`.

This also fixes the anchor permanence label to ensure we search the label name wrapped in "quotes", so the whole label name is what gets searched for and not just the first word. Also, how do these labels get created? I feel like I've seen something about org-wide labels, but I noticed I cannot apply an "anchor permanence" label to anything in whatwg/console.

/cc @chrisdavidmills