### PR TITLE
Simplify review draft flow

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -92,8 +92,11 @@ The `git push --force` line here ensures that the original branch gets updated t
 As per the [Workstream Policy](https://whatwg.org/workstream-policy#review-drafts), editors are expected to publish a Review Draft every six months. This is a manual process ([for now](https://github.com/whatwg/sg/issues/74)):
 
 1. Run `make review` and follow the instructions.
-1. Commit the new document. Use a commit message like `Meta: May 2018 Review Draft` (adjusting the month and year accordingly).
-1. Create a pull request for the new resource and get it reviewed.
+1. Commit the new document. Use a commit message like `Review Draft Publication: May 2018` (adjusting the month and year accordingly). This format (which translates into the pull request title) is important for those filtering their notifications in their email client.
+1. Create a pull request for the new resource and get it reviewed. The pull request body should be:
+   ```markdown
+   A Review Draft for this Workstream will be published shortly, by merging this pull request.
+
+   Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.
+   ```
 1. Land the pull request. This will automatically publish the review draft in a subdirectory of `https://x.spec.whatwg.org/review-drafts/`.
-1. Open an issue on the standard's repository to announce the new Review Draft. Use an issue title like `[Review Draft Announcement] May 2018`; this is important for those filtering their notifications in their email client.
-1. After 45 days of inactivity on the issue, close it. If there is activity, contact the [SG](https://github.com/whatwg/sg).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -99,4 +99,4 @@ As per the [Workstream Policy](https://whatwg.org/workstream-policy#review-draft
 
    Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.
    ```
-1. Land the pull request. This will automatically publish the review draft in a subdirectory of `https://x.spec.whatwg.org/review-drafts/`.
+1. Land the pull request. This will automatically publish the review draft in a subdirectory of <code>https://<var>x</var>.spec.whatwg.org/review-drafts/</code>.


### PR DESCRIPTION
@annevk, this seems a bit simpler and has the added bonus of providing some advance notice before the pull request lands. (TBD whether we should suggest editors delay some time between posting and merging.) What do you think?

/cc @whatwg/editors 