### PR TITLE
Automate some tasks of the Review Draft reviewer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -78,7 +78,7 @@ checkout-pr estark37 example-fix
 
 Per the [Workstream Policy](https://whatwg.org/workstream-policy#review-drafts), editors are expected to publish a Review Draft every six months.
 
-In practice the `review.py` script is used, this:
+To accomplish this the `review.py` script is used, this:
 
 1. Runs `make review` for each draft scheduled to be published that month as per [db.json](https://github.com/whatwg/sg/blob/master/db.json).
 1. Creates a pull request for the changes. The pull request body will be:
@@ -88,6 +88,4 @@ In practice the `review.py` script is used, this:
    Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.
    ```
 
-Someone will then review all is in order and merge it.
-
-Both of these tasks are not neccessarily performed by the editor of a draft as they are largely automated and do not require editor discretion.
+The editor or deputy editor will then review all is in order and merge it.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -76,14 +76,18 @@ checkout-pr estark37 example-fix
 
 ## Review Drafts
 
-As per the [Workstream Policy](https://whatwg.org/workstream-policy#review-drafts), editors are expected to publish a Review Draft every six months. This is a manual process ([for now](https://github.com/whatwg/sg/issues/74)):
+Per the [Workstream Policy](https://whatwg.org/workstream-policy#review-drafts), editors are expected to publish a Review Draft every six months.
 
-1. Run `make review` and review the shown diff. This will also create a branch with a new commit. Please do not adjust the commit message; the pull request title generated from it is important for those filtering their notifications in their email client.
-1. Create a pull request for the new resource and get it reviewed. The pull request body should be:
+In practice the `review.py` script is used, this:
+
+1. Runs `make review` for each draft scheduled to be published that month as per [db.json](https://github.com/whatwg/sg/blob/master/db.json).
+1. Creates a pull request for the changes. The pull request body will be:
    ```markdown
-   A Review Draft for this Workstream will be published shortly, by merging this pull request.
+   A MONTH YEAR Review Draft (linked) for this Workstream will be published shortly after merging this pull request.
 
    Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.
    ```
-1. Land the pull request. This will automatically publish the review draft in a subdirectory of <code>https://<var>x</var>.spec.whatwg.org/review-drafts/</code>.
-1. Copy the final URL and add it as a comment to the pull request.
+
+Someone will then review all is in order and merge it.
+
+Both of these tasks are not neccessarily performed by the editor of a draft as they are largely automated and do not require editor discretion.

--- a/review.py
+++ b/review.py
@@ -58,19 +58,21 @@ def maybe_create_pr(shortname):
         else:
             break
 
+    today = datetime.datetime.today()
+    nice_month = today.strftime("%B %Y")
+    path_month = today.strftime("%Y-%m")
+
     # We should consider merging
     # https://github.com/whatwg/whatwg.org/blob/master/resources.whatwg.org/build/review.sh and
     # https://github.com/whatwg/html/blob/master/review-draft.sh into this script.
     subprocess.run(["make", "review"])
 
     # This is straight from MAINTAINERS.md and needs to be kept in sync with that.
-    pr_body = """A Review Draft for this Workstream will be published shortly, by merging this pull request.
+    pr_body = """The [{} Review Draft](https://{}.spec.whatwg.org/review-drafts/{}) for this Workstream will be published shortly after merging this pull request.
 
-Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details."""
+Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.""".format(nice_month, shortname, path_month)
 
-    # TODO: should we expand pr_body to include instructions for the maintainer with respect to the
-    # subsequent comment and such?
-    subprocess.run(["gh", "pr", "create", "--title", "Review Draft Publication: {}".format(datetime.datetime.now().strftime("%B %G")), "--body", pr_body])
+    subprocess.run(["gh", "pr", "create", "--title", "Review Draft Publication: {}".format(nice_month), "--body", pr_body])
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
@foolip would this be reason enough to reword https://whatwg.org/workstream-policy#schedule a bit to be more vague as to who is in charge of publishing Review Drafts?