### PR TITLE
Fix #251. Fixes cases check for commit.

### DIFF
--- a/review.py
+++ b/review.py
@@ -57,6 +57,7 @@ def maybe_create_pr(shortname):
     subprocess.run(["git", "pull"], capture_output=True)
     commits = subprocess.run(["git", "log", "--format=%s", "--max-count=40"], capture_output=True).stdout
     for subject in commits.split(b"\n"):
+        subject = subject.title()
         if subject.startswith(b"Meta:"):
             continue
         elif subject.startswith(b"Review Draft Publication:"):


### PR DESCRIPTION
Fix #251

This fixes the python code for the case check to avoid unwanted tweets 

This doesn't fix https://github.com/whatwg/participate.whatwg.org/blob/main/lib/compose-tweet.js#L5
which is on a different repo. 