### PR TITLE
Add agenda+ label to labels.json

### DIFF
--- a/labels.json
+++ b/labels.json
@@ -22,6 +22,11 @@
     "name": "addition/proposal"
   },
   {
+    "color": "000000",
+    "description": "To be discussed at triage meeting",
+    "name": "agenda+"
+  },
+  {
     "color": "ececec",
     "description": "Identifies issues opened by other standards organizations, as per WHATWG's [anchor permanence policy](https://whatwg.org/working-mode#anchors)",
     "name": "anchor permanence",


### PR DESCRIPTION
This is already used in whatwg/html, and issues from other repos are occasionally discussed as well.