### PR TITLE
Add `invalid` to LABELS.md

### DIFF
--- a/LABELS.md
+++ b/LABELS.md
@@ -24,6 +24,7 @@ These are labels used by all [WHATWG standards](https://spec.whatwg.org/):
 * [i18n-mlreq](https://github.com/search?q=org%3Awhatwg+label%3A%22i18n-mlreq%22+is%3Aopen): Notifies traditional Mongolian script experts of relevant issues
 * [impacts documentation](https://github.com/search?q=org%3Awhatwg+label%3A%22impacts+documentation%22): Used by documentation communities, such as MDN, to track changes that impact documentation
 * [interop](https://github.com/search?q=org%3Awhatwg+label%3A%22interop%22+is%3Aopen): Implementations are not interoperable with each other
+* [invalid](https://github.com/search?q=org%3Awhatwg+label%3A%22invalid%22+is%3Aopen): Used to mark off-topic or spam issues or PRs
 * [meta](https://github.com/search?q=org%3Awhatwg+label%3A%22meta%22+is%3Aopen): Changes to the ecosystem around the standard, not its contents.
 * [needs concrete proposal](https://github.com/search?q=org%3Awhatwg+label%3A%22needs+concrete+proposal%22+is%3Aopen): Moving the issue forward requires someone to figure out a detailed plan
 * [needs implementer interest](https://github.com/search?q=org%3Awhatwg+label%3A%22needs+implementer+interest%22+is%3Aopen): Moving the issue forward requires implementers to express interest

--- a/labels.json
+++ b/labels.json
@@ -126,6 +126,11 @@
     "name": "interop"
   },
   {
+    "color": "e4e669",
+    "description": "Used to mark off-topic or spam issues or PRs",
+    "name": "invalid"
+  },
+  {
     "color": "fcabe1",
     "description": "Changes to the ecosystem around the standard, not its contents.",
     "name": "meta"


### PR DESCRIPTION
This adds the `invalid` label, to the `LABELS.md`.

The motivation for such a label is to properly mark these issues as spam. The specific `invalid` label is one of the signals used by spam detection algorithms at GitHub which allows us to more easily surface spam issues to the spam team.